### PR TITLE
Fix: Context Menu does not open properly on Firefox

### DIFF
--- a/src/ContextMenuWrapper.js
+++ b/src/ContextMenuWrapper.js
@@ -128,7 +128,7 @@ export default class ContextMenuWrapper extends Component {
         document.addEventListener('touchstart', this.handleClick);
 
         // Firefox workaround, see constructor
-        if (isFirefox()) document.addEventListener('mouseup', this.handleMouseup);
+        if (isFirefox) document.addEventListener('mouseup', this.handleMouseup);
 
         // Setup toggleable handlers
         for (const toggleProp of this.toggleProps) {
@@ -216,9 +216,7 @@ export default class ContextMenuWrapper extends Component {
      */
     handleClick = (event) => {
         const isRightClick = event.button === 2;
-        if (isFirefox() && this.ignoreRightClick && isRightClick) {
-            return;
-        }
+        if (isFirefox && this.ignoreRightClick && isRightClick) return;
 
         if (!this.state.visible) return;
 

--- a/src/ContextMenuWrapper.js
+++ b/src/ContextMenuWrapper.js
@@ -178,8 +178,21 @@ export default class ContextMenuWrapper extends Component {
         registerShowIntent(showIntent);
     };
 
+    /**
+     * Clicking might imply that we should close the context menu.
+     */
     handleClick = (event) => {
-        if (!this.state.visible) return;
+        /*
+        Firefox has a bug where it dispatches a click event when a contextmenu
+        event is dispatched. It's been open for 17 years!
+        https://bugzilla.mozilla.org/show_bug.cgi?id=184051
+        Hence, on Firefox, the context menu would immediately close on releasing
+        the right mouse button.
+        => Not closing the context menu on right button clicks fixes the issue.
+        */
+        const isRightClick = event.button === 2;
+
+        if (!this.state.visible || isRightClick) return;
 
         const node = this.nodeRef.current;
         const wasOutside = event.target !== node && !node.contains(event.target);

--- a/src/util.js
+++ b/src/util.js
@@ -457,3 +457,7 @@ export function determineContextMenuPlacement(params) {
 
     return {x, y};
 }
+
+export function isFirefox() {
+    return navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+}

--- a/src/util.js
+++ b/src/util.js
@@ -458,6 +458,4 @@ export function determineContextMenuPlacement(params) {
     return {x, y};
 }
 
-export function isFirefox() {
-    return navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-}
+export const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;


### PR DESCRIPTION
This fixes an issue where the react-context-menu-wrapper is unusable in Firefox:
[It is a known problem in Firefox that when a contextmenu event is dispatched on a right mouse click, a click event is also dispatched](https://bugzilla.mozilla.org/show_bug.cgi?id=184051). This would cause the context menu to open while holding the right mouse button and close it immediately when the right mouse button was released. The intended behavior would be to leave the context menu open on mouse button release.

Fix: In the event handler for mouse clicks, check if the click is a right mouse click. If so, stop the logic from closing the context menu. Previous assumption was to close the context menu every time a mouse click was encountered.

Let me know if I should move the comment to the commit message instead of in the file.